### PR TITLE
Fix detection of Vala compiler at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ if test x"$enable_actions" = xyes; then
         AM_PROG_VALAC
     else
         AM_PROG_VALAC([0.13.0])
-        if test x"$VALAC" = x; then
+        if test x"$VALAC" = xvalac; then
             AC_ERROR([No Vala compiler found but it is required.])
         fi
     fi


### PR DESCRIPTION
VALAC is set to "valac" if no suitable compiler was found. See
https://www.gnu.org/software/automake/manual/html_node/Vala-Support.html