### PR TITLE
libfm-pref-apps: don't show in LXQt

### DIFF
--- a/data/libfm-pref-apps.desktop.in
+++ b/data/libfm-pref-apps.desktop.in
@@ -6,4 +6,4 @@ Icon=preferences-desktop
 Exec=libfm-pref-apps
 StartupNotify=true
 Categories=Settings;DesktopSettings;X-LXDE-Settings;GTK;
-NotShowIn=GNOME;XFCE;KDE;MATE;
+OnlyShowIn=LXDE;


### PR DESCRIPTION
LXQt comes with its own components to select default applications. These may not be in a too good shape right now but they exist and will always be available.
So the panel main menu in LXQt shouldn't provide yet another component to set default applications as this does not offer any advantage but is rather confusing only.
