### PR TITLE
Fix use after free error.

### DIFF
--- a/src/base/fm-config.c
+++ b/src/base/fm-config.c
@@ -193,10 +193,15 @@ FmConfig *fm_config_new(void)
 static void _on_cfg_file_changed(GFileMonitor *mon, GFile *gf, GFile *other,
                                  GFileMonitorEvent evt, FmConfig *cfg)
 {
+    gchar * tmpname;
     if (evt == G_FILE_MONITOR_EVENT_DELETED)
         _cfg_monitor_free(cfg);
     else
-        fm_config_load_from_file(cfg, cfg->_cfg_name);
+    {
+        tmpname = g_strdup(cfg->_cfg_name);
+        fm_config_load_from_file(cfg, tmpname);
+	g_free(tmpname);
+    }
 }
 
 /**


### PR DESCRIPTION
This fixes a use after free error.

The problem is this piece of code in fm-config.c:
        fm_config_load_from_file(cfg, cfg->_cfg_name);

Inside fm_config_load_from_file() the _cfg_name property of cfg will get free'd. After that it will assign the name parameter to it. Now if you set the name parameter to cfg->_cfg_name in the first place this means that it will first get free'd and then assigned. So this function cannot be called like this, we first need to create a copy of the string we want to pass as a parameter.

(If you don't like the patch: This could also be fixed in other ways, e.g. checking inside fm_config_load_from_file() whether cfg->_cfg_name and name are the same pointer.)

This bug was found with the help of address sanitizer.
