### PR TITLE
Fix a crash on searching

### DIFF
--- a/src/modules/vfs-search.c
+++ b/src/modules/vfs-search.c
@@ -564,7 +564,9 @@ static void parse_search_uri(FmVfsSearchEnumerator* priv, const char* uri_str)
 
             if(name_regex)
             {
-                GRegexCompileFlags flags = 0;
+                /* we set G_REGEX_RAW because GLib might cause a crash
+                   if a search is done in a non-utf8 string */
+                GRegexCompileFlags flags = G_REGEX_RAW;
                 if(priv->name_case_insensitive)
                     flags |= G_REGEX_CASELESS;
                 priv->name_regex = g_regex_new(name_regex, flags, 0, NULL);
@@ -573,7 +575,7 @@ static void parse_search_uri(FmVfsSearchEnumerator* priv, const char* uri_str)
 
             if(content_regex)
             {
-                GRegexCompileFlags flags = 0;
+                GRegexCompileFlags flags = G_REGEX_RAW; /* like above */
                 if(priv->content_case_insensitive)
                     flags |= G_REGEX_CASELESS;
                 priv->content_regex = g_regex_new(content_regex, flags, 0, NULL);


### PR DESCRIPTION
This commit definitely fixes https://github.com/lxde/lxqt/issues/1058.

GLib might cause a crash if `g_regex_match()` is fed by a non-utf8 string while `G_REGEX_RAW` is not set. I consider this as a bug because, first, GLib behaves inconsistently in such cases and, second, crashing instead of giving a false result is unacceptable. Anyway, in this commit, `G_REGEX_RAW` is used.

There were other ways of avoiding the crash like validating the strings by `g_utf8_validate()` or using `g_data_input_stream_read_line_utf8()` but, in their case, the search wouldn't be done in non-utf8 texts (correctly). Apart from valid texts with encodings other than utf8, sometimes searching for metadata in a PDF file, for example, is useful.