### PR TITLE
Properly initialize GError with NULL

### DIFF
--- a/src/base/fm-templates.c
+++ b/src/base/fm-templates.c
@@ -348,7 +348,7 @@ static void _fm_template_update_from_file(FmTemplate *templ, FmTemplateFile *fil
         GKeyFile *kf = g_key_file_new();
         char *filename = fm_path_to_str(file->path);
         char *tmp;
-        GError *error;
+        GError *error = NULL;
         gboolean hidden;
 
         if(g_key_file_load_from_file(kf, filename, G_KEY_FILE_NONE, &error))


### PR DESCRIPTION
ref: https://bugzilla.redhat.com/show_bug.cgi?id=1357213

When g_key_file_load_from_file(... , &error) fails,
the error contents is supposed to be set to error.
However actually reading g_key_file_load_from_file()
implementation shows that unless error is initialized to
NULL before calling g_key_file_load_from_file(), the
function leaves error unchanged.
So afterwards, g_error_free(error) tries to free uninitialized
pointer, which causes SIGABRT.