### PR TITLE
Fixes FTBFS when libmenu-cache as installed to non-standard location

### DIFF
--- a/src/modules/vfs-menu.c
+++ b/src/modules/vfs-menu.c
@@ -30,7 +30,7 @@
 #include "fm-xml-file.h"
 
 #include <glib/gi18n-lib.h>
-#include <menu-cache/menu-cache.h>
+#include <menu-cache.h>
 
 /* support for libmenu-cache 0.4.x */
 #ifndef MENU_CACHE_CHECK_VERSION


### PR DESCRIPTION
libmenu-cache pkg-config file defines Cflags as:
    Cflags: -I${includedir}/menu-cache
So #include <menu-cache/menu-cache.h> works only if ${includedir} is
included by default, e.g. standard locations. When libmenu-cache was
installed to a non-standard location ${includedir} is not part of the
default include path and #include <menu-cache/menu-cache.h> fails.