### PR TITLE
Prevent corrupted image thumbnails

### DIFF
--- a/src/base/fm-thumbnail-loader.c
+++ b/src/base/fm-thumbnail-loader.c
@@ -807,11 +807,10 @@ static void generate_thumbnails(ThumbnailTask* task)
     if (fm_file_info_is_image(task->fi) &&
         /* if the image file is too large, don't generate thumbnail for it. */
         (fm_config->thumbnail_max == 0 ||
-         (fm_file_info_get_size(task->fi) <= (fm_config->thumbnail_max << 10))) &&
-            generate_thumbnails_with_builtin(task))
-        ;
-        /* if image is too large or the built-in thumbnail generation fails
-         * still call external thumbnailer to handle it. */
+         fm_file_info_get_size(task->fi) <= (fm_config->thumbnail_max << 10)))
+    {
+        generate_thumbnails_with_builtin(task);
+    }
     else
         generate_thumbnails_with_thumbnailers(task);
 


### PR DESCRIPTION
Since `generate_thumbnails_with_builtin()` is in thread, it may not have time to return a TRUE value in `fm-thumbnail-loader.c → generate_thumbnails()`, so that if there is an external image thumbnailer (like the PNG thumbnailer of gdk-pixbuf2 >= 2.36.1), a corrupted thumbnail will be imminent.

Please see that the above statement is just a speculation. However, this patch really prevents creation of corrupted thumbnails of PNG images with gdk-pixbuf2 >= 2.36.1. I also did some tests with a `gboolean`, to which the return value of `generate_thumbnails_with_builtin()` was assigned, and it always remained equal to its initial value, whether it was TRUE or FALSE.