### PR TITLE
Treat desktop entries as executables

### DIFF
--- a/src/base/fm-file-info.c
+++ b/src/base/fm-file-info.c
@@ -1361,7 +1361,8 @@ gboolean fm_file_info_is_unknown_type(FmFileInfo* fi)
 /* full path of the file is required by this function */
 gboolean fm_file_info_is_executable_type(FmFileInfo* fi)
 {
-    if(strncmp(fm_mime_type_get_type(fi->mime_type), "text/", 5) == 0)
+    const char* type = fm_mime_type_get_type(fi->mime_type);
+    if(strncmp(type, "text/", 5) == 0)
     { /* g_content_type_can_be_executable reports text files as executables too */
         /* We don't execute remote files nor files in trash */
         if(fm_path_is_native(fi->path) && (fi->mode & (S_IXOTH|S_IXGRP|S_IXUSR)))
@@ -1378,6 +1379,13 @@ gboolean fm_file_info_is_executable_type(FmFileInfo* fi)
                     return TRUE;
             }
         }
+        return FALSE;
+    }
+    else if(strcmp(type, "application/x-desktop") == 0)
+    { /* treat desktop entries as executables if
+         they are native and have read permission */
+        if(fm_path_is_native(fi->path) && (fi->mode & (S_IRUSR|S_IRGRP|S_IROTH)))
+            return TRUE;
         return FALSE;
     }
     return g_content_type_can_be_executable(fm_mime_type_get_type(fi->mime_type));

--- a/src/base/fm-file-launcher.c
+++ b/src/base/fm-file-launcher.c
@@ -202,13 +202,55 @@ gboolean fm_launch_files(GAppLaunchContext* ctx, GList* file_infos, FmFileLaunch
         else if (fm_file_info_is_desktop_entry(fi))
         {
 _launch_desktop_entry:
-            if (!target)
-                filename = fm_path_to_str(fm_file_info_get_path(fi));
-            fm_launch_desktop_entry(ctx, target ? target : filename, NULL,
-                                    launcher, user_data);
-            if (!target)
-                g_free(filename);
-            continue;
+            /* treat desktop entries as executables */
+            if(fm_file_info_is_executable_type(fi))
+            {
+                switch(launcher->exec_file(fi, user_data))
+                {
+                case FM_FILE_LAUNCHER_EXEC_IN_TERMINAL:
+                case FM_FILE_LAUNCHER_EXEC:
+                {
+                    if (!target)
+                        filename = fm_path_to_str(fm_file_info_get_path(fi));
+                    fm_launch_desktop_entry(ctx, target ? target : filename, NULL,
+                                            launcher, user_data);
+                    if (!target)
+                        g_free(filename);
+                    continue;
+                }
+                case FM_FILE_LAUNCHER_EXEC_OPEN:
+                    break;
+                case FM_FILE_LAUNCHER_EXEC_CANCEL:
+                    continue;
+               }
+            }
+            /* make exception for desktop entries under menu */
+            else if(fm_path_is_xdg_menu(fm_file_info_get_path(fi)))
+            {
+                if (!target)
+                    filename = fm_path_to_str(fm_file_info_get_path(fi));
+                fm_launch_desktop_entry(ctx, target ? target : filename, NULL,
+                                        launcher, user_data);
+                if (!target)
+                    g_free(filename);
+                continue;
+            }
+
+            FmMimeType* mime_type = fm_file_info_get_mime_type(fi);
+            if(mime_type && (type = fm_mime_type_get_type(mime_type)))
+            {
+                fis = g_hash_table_lookup(hash, type);
+                fis = g_list_prepend(fis, fi);
+                g_hash_table_insert(hash, (gpointer)type, fis);
+            }
+            else if (launcher->error)
+            {
+                g_set_error(&err, G_IO_ERROR, G_IO_ERROR_FAILED,
+                            _("Could not determine content type of file '%s' to launch it"),
+                            fm_file_info_get_disp_name(fi));
+                launcher->error(ctx, err, NULL, user_data);
+                g_clear_error(&err);
+            }
         }
         else
         {
@@ -269,7 +311,7 @@ _launch_desktop_entry:
                     if (fm_file_info_is_desktop_entry(fi))
                         goto _launch_desktop_entry;
                 }
-                if(fm_file_info_is_executable_type(fi))
+                if(fm_file_info_is_executable_type(fi) && !fm_file_info_is_desktop_entry(fi))
                 {
                     /* if it's an executable file, directly execute it. */
                     filename = fm_path_to_str(path);


### PR DESCRIPTION
Fixes https://github.com/lxde/pcmanfm-qt/issues/449.

With this patch, clicking on a native desktop file opens a confirmation dialog instead of executing it. Trashed desktop files are only opened as text files and desktop files under menu (menu://applications/) are executed without prompt as before.

Recently, several users became worried about dangers of executing (native) desktop files without confirmation. I think they are right: promptless execution of desktop files is a significant security issue.

This PR will be followed by a small libfm-qt PR to have an appropriate confirmation dialog for desktop files.