### PR TITLE
Fix build error with vala 0.36.1

### DIFF
--- a/src/actions/action.vala
+++ b/src/actions/action.vala
@@ -78,7 +78,7 @@ public class FileAction : FileActionObject {
 		id = desktop_id;
 		try {
 			kf.load_from_file(desktop_id, 0);
-			FileAction.from_keyfile(kf);
+			this.from_keyfile(kf);
 		}
 		catch(KeyFileError err) {
 		}
@@ -141,7 +141,7 @@ public class FileActionMenu : FileActionObject {
 		id = desktop_id;
 		try {
 			kf.load_from_file(desktop_id, 0);
-			FileActionMenu.from_keyfile(kf);
+			this.from_keyfile(kf);
 		}
 		catch(KeyFileError err) {
 		}


### PR DESCRIPTION
On Fedora 26 (using vala 0.36.1), rebuilding libfm causes
a error as:
```
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/valac --thread --vapidir=./../vapi --pkg gio-2.0 --pkg posix --pkg libfm --vapi ./../vapi/fm-actions.vapi --header fm-actions.h   -C action.vala condition.vala profile.vala parameters.vala utils.vala
condition.vala:149.18-155.34: warning: unhandled error `GLib.Error'
condition.vala:192.8-193.40: warning: unhandled error `GLib.SpawnError'
action.vala:81.4-81.30: error: use `new' operator to create new objects
			FileAction.from_keyfile(kf);
			^^^^^^^^^^^^^^^^^^^^^^^^^^^
action.vala:144.4-144.34: error: use `new' operator to create new objects
			FileActionMenu.from_keyfile(kf);
			^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
Instead of using class name, "this" must be used here.