### PR TITLE
Fix segv on pasting large string when completion matches

### DIFF
--- a/src/gtk/fm-path-entry.c
+++ b/src/gtk/fm-path-entry.c
@@ -746,7 +746,7 @@ static void fm_path_entry_completion_render_func(GtkCellLayout *cell_layout,
     gtk_tree_model_get(model, iter, COL_BASENAME, &model_file_name, -1);
     model_file_name_len = strlen(model_file_name);
 
-    if( priv->highlight_completion_match )
+    if( priv->highlight_completion_match && (model_file_name_len >= priv->typed_basename_len) )
     {
         int buf_len = model_file_name_len + 14 + 1;
         gchar* markup = g_malloc(buf_len);


### PR DESCRIPTION
Original report: https://bugzilla.redhat.com/show_bug.cgi?id=1437443
A pcmanfm crash is reproducible with the following step.

1.  launch a terminal (like lxterminal)
2.  On the terminal, execute ``$ cd /tmp``
3.  ``$ mkdir test``
4.  ``$ cd test``
5.  ``$ mkdir test1 test2``
6.  ``$ touch test.file.txt test2.doc test5.tgz``
7.  Then launch pcmanfm as ``$ pcmanfm`` (from the terminal). Then pcmanfm's URL bar should show "/tmp/test"
8.  On pcmanfm file list (or icon list), choose (one click) "test.file.txt" entry and type F2.
9.  Then "Rename File" dialog appears and the column shows "test.file.txt", with the part "test.file" highlightened. Select the whole string "test.file.txt" and copy it (with Ctrl-C, for example), then close the dialog with "Cancel".
10.  Now click pcmanfm URL bar (showing "/tmp/test"), and type "/" at the end of the string.
11.  Now following "/tmp/test/" string, "test" string is automatically completed with the completed part highlightened (and the URL bar now showing /test/test/test"). Also two completion candidate (test2 and test1) appears.
12.  Now (with "test" part heighlightened), do paste (with Ctrl-V).

Now you see pcmanfm crashes.
Valgrind shows:
```
[tasaka1@8C-0D-76-DB-D7-3C test]$ valgrind pcmanfm
==26197== Memcheck, a memory error detector
==26197== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==26197== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==26197== Command: pcmanfm
==26197== 

(pcmanfm:26197): Gtk-WARNING **: Theme parsing error: <data>:2:27: The style property GtkWidget:focus-padding is deprecated and shouldn't be used anymore. It will be removed in a future version

(pcmanfm:26197): Gtk-WARNING **: Theme parsing error: <data>:3:30: The style property GtkWidget:focus-line-width is deprecated and shouldn't be used anymore. It will be removed in a future version
==26197== Invalid write of size 1
==26197==    at 0x4C34E18: stpcpy (vg_replace_strmem.c:1139)
==26197==    by 0x57E7F27: fm_path_entry_completion_render_func (fm-path-entry.c:756)
==26197==    by 0x5B3C722: apply_cell_attributes (gtkcellarea.c:1257)
==26197==    by 0x54C84EF: g_hash_table_foreach (ghash.c:1608)
==26197==    by 0x5B3C5BA: gtk_cell_area_real_apply_attributes (gtkcellarea.c:1286)
==26197==    by 0x5B420D8: gtk_cell_area_box_apply_attributes (gtkcellareabox.c:1310)
==26197==    by 0x5C3DE7E: _gtk_marshal_VOID__OBJECT_BOXED_BOOLEAN_BOOLEANv (gtkmarshalers.c:5027)
==26197==    by 0x7BCC535: _g_closure_invoke_va (gclosure.c:867)
==26197==    by 0x7BE74B3: g_signal_emit_valist (gsignal.c:3300)
==26197==    by 0x7BE7B1E: g_signal_emit (gsignal.c:3447)
==26197==    by 0x5B3E1E9: gtk_cell_area_apply_attributes (gtkcellarea.c:2373)
==26197==    by 0x5AAA57C: set_cell_data (gtktreeviewaccessible.c:336)
==26197==  Address 0x1a681f04 is 0 bytes after a block of size 20 alloc'd
==26197==    at 0x4C2EB1B: malloc (vg_replace_malloc.c:299)
==26197==    by 0x54DE9C8: g_malloc (gmem.c:94)
==26197==    by 0x57E7EF2: fm_path_entry_completion_render_func (fm-path-entry.c:752)
==26197==    by 0x5B3C722: apply_cell_attributes (gtkcellarea.c:1257)
==26197==    by 0x54C84EF: g_hash_table_foreach (ghash.c:1608)
==26197==    by 0x5B3C5BA: gtk_cell_area_real_apply_attributes (gtkcellarea.c:1286)
==26197==    by 0x5B420D8: gtk_cell_area_box_apply_attributes (gtkcellareabox.c:1310)
==26197==    by 0x5C3DE7E: _gtk_marshal_VOID__OBJECT_BOXED_BOOLEAN_BOOLEANv (gtkmarshalers.c:5027)
==26197==    by 0x7BCC535: _g_closure_invoke_va (gclosure.c:867)
==26197==    by 0x7BE74B3: g_signal_emit_valist (gsignal.c:3300)
==26197==    by 0x7BE7B1E: g_signal_emit (gsignal.c:3447)
==26197==    by 0x5B3E1E9: gtk_cell_area_apply_attributes (gtkcellarea.c:2373)
==26197== 
==26197== Invalid write of size 1
==26197==    at 0x4C34E2C: stpcpy (vg_replace_strmem.c:1139)
==26197==    by 0x57E7F27: fm_path_entry_completion_render_func (fm-path-entry.c:756)
==26197==    by 0x5B3C722: apply_cell_attributes (gtkcellarea.c:1257)
==26197==    by 0x54C84EF: g_hash_table_foreach (ghash.c:1608)
==26197==    by 0x5B3C5BA: gtk_cell_area_real_apply_attributes (gtkcellarea.c:1286)
==26197==    by 0x5B420D8: gtk_cell_area_box_apply_attributes (gtkcellareabox.c:1310)
==26197==    by 0x5C3DE7E: _gtk_marshal_VOID__OBJECT_BOXED_BOOLEAN_BOOLEANv (gtkmarshalers.c:5027)
==26197==    by 0x7BCC535: _g_closure_invoke_va (gclosure.c:867)
==26197==    by 0x7BE74B3: g_signal_emit_valist (gsignal.c:3300)
==26197==    by 0x7BE7B1E: g_signal_emit (gsignal.c:3447)
==26197==    by 0x5B3E1E9: gtk_cell_area_apply_attributes (gtkcellarea.c:2373)
==26197==    by 0x5AAA57C: set_cell_data (gtktreeviewaccessible.c:336)
==26197==  Address 0x1a681f0b is 7 bytes after a block of size 20 alloc'd
==26197==    at 0x4C2EB1B: malloc (vg_replace_malloc.c:299)
==26197==    by 0x54DE9C8: g_malloc (gmem.c:94)
==26197==    by 0x57E7EF2: fm_path_entry_completion_render_func (fm-path-entry.c:752)
==26197==    by 0x5B3C722: apply_cell_attributes (gtkcellarea.c:1257)
==26197==    by 0x54C84EF: g_hash_table_foreach (ghash.c:1608)
==26197==    by 0x5B3C5BA: gtk_cell_area_real_apply_attributes (gtkcellarea.c:1286)
==26197==    by 0x5B420D8: gtk_cell_area_box_apply_attributes (gtkcellareabox.c:1310)
==26197==    by 0x5C3DE7E: _gtk_marshal_VOID__OBJECT_BOXED_BOOLEAN_BOOLEANv (gtkmarshalers.c:5027)
==26197==    by 0x7BCC535: _g_closure_invoke_va (gclosure.c:867)
==26197==    by 0x7BE74B3: g_signal_emit_valist (gsignal.c:3300)
==26197==    by 0x7BE7B1E: g_signal_emit (gsignal.c:3447)
==26197==    by 0x5B3E1E9: gtk_cell_area_apply_attributes (gtkcellarea.c:2373)
==26197== 
==26197== Invalid read of size 1
==26197==    at 0x819EE90: __stpcpy_ssse3 (strcpy-ssse3.S:32)
==26197==    by 0x57E7F37: fm_path_entry_completion_render_func (fm-path-entry.c:757)
==26197==    by 0x5B3C722: apply_cell_attributes (gtkcellarea.c:1257)
==26197==    by 0x54C84EF: g_hash_table_foreach (ghash.c:1608)
==26197==    by 0x5B3C5BA: gtk_cell_area_real_apply_attributes (gtkcellarea.c:1286)
==26197==    by 0x5B420D8: gtk_cell_area_box_apply_attributes (gtkcellareabox.c:1310)
==26197==    by 0x5C3DE7E: _gtk_marshal_VOID__OBJECT_BOXED_BOOLEAN_BOOLEANv (gtkmarshalers.c:5027)
==26197==    by 0x7BCC535: _g_closure_invoke_va (gclosure.c:867)
==26197==    by 0x7BE74B3: g_signal_emit_valist (gsignal.c:3300)
==26197==    by 0x7BE7B1E: g_signal_emit (gsignal.c:3447)
==26197==    by 0x5B3E1E9: gtk_cell_area_apply_attributes (gtkcellarea.c:2373)
==26197==    by 0x5AAA57C: set_cell_data (gtktreeviewaccessible.c:336)
==26197==  Address 0x1a681ead is 7 bytes after a block of size 6 alloc'd
==26197==    at 0x4C2EB1B: malloc (vg_replace_malloc.c:299)
==26197==    by 0x54DE9C8: g_malloc (gmem.c:94)
==26197==    by 0x54F801E: g_strdup (gstrfuncs.c:363)
==26197==    by 0x7BF709C: value_lcopy_string (gvaluetypes.c:312)
==26197==    by 0x5D48FB0: gtk_tree_model_get_valist (gtktreemodel.c:1800)
==26197==    by 0x5D4925C: gtk_tree_model_get (gtktreemodel.c:1762)
==26197==    by 0x57E7E90: fm_path_entry_completion_render_func (fm-path-entry.c:746)
==26197==    by 0x5B3C722: apply_cell_attributes (gtkcellarea.c:1257)
==26197==    by 0x54C84EF: g_hash_table_foreach (ghash.c:1608)
==26197==    by 0x5B3C5BA: gtk_cell_area_real_apply_attributes (gtkcellarea.c:1286)
==26197==    by 0x5B420D8: gtk_cell_area_box_apply_attributes (gtkcellareabox.c:1310)
==26197==    by 0x5C3DE7E: _gtk_marshal_VOID__OBJECT_BOXED_BOOLEAN_BOOLEANv (gtkmarshalers.c:5027)
==26197== 
==26197== Invalid write of size 1
==26197==    at 0x4C34EBB: stpcpy (vg_replace_strmem.c:1139)
==26197==    by 0x57E7F37: fm_path_entry_completion_render_func (fm-path-entry.c:757)
==26197==    by 0x5B3C722: apply_cell_attributes (gtkcellarea.c:1257)
==26197==    by 0x54C84EF: g_hash_table_foreach (ghash.c:1608)
==26197==    by 0x5B3C5BA: gtk_cell_area_real_apply_attributes (gtkcellarea.c:1286)
==26197==    by 0x5B420D8: gtk_cell_area_box_apply_attributes (gtkcellareabox.c:1310)
==26197==    by 0x5C3DE7E: _gtk_marshal_VOID__OBJECT_BOXED_BOOLEAN_BOOLEANv (gtkmarshalers.c:5027)
==26197==    by 0x7BCC535: _g_closure_invoke_va (gclosure.c:867)
==26197==    by 0x7BE74B3: g_signal_emit_valist (gsignal.c:3300)
==26197==    by 0x7BE7B1E: g_signal_emit (gsignal.c:3447)
==26197==    by 0x5B3E1E9: gtk_cell_area_apply_attributes (gtkcellarea.c:2373)
==26197==    by 0x5AAA57C: set_cell_data (gtktreeviewaccessible.c:336)
==26197==  Address 0x1a681f0b is 7 bytes after a block of size 20 alloc'd
==26197==    at 0x4C2EB1B: malloc (vg_replace_malloc.c:299)
==26197==    by 0x54DE9C8: g_malloc (gmem.c:94)
==26197==    by 0x57E7EF2: fm_path_entry_completion_render_func (fm-path-entry.c:752)
==26197==    by 0x5B3C722: apply_cell_attributes (gtkcellarea.c:1257)
==26197==    by 0x54C84EF: g_hash_table_foreach (ghash.c:1608)
==26197==    by 0x5B3C5BA: gtk_cell_area_real_apply_attributes (gtkcellarea.c:1286)
==26197==    by 0x5B420D8: gtk_cell_area_box_apply_attributes (gtkcellareabox.c:1310)
==26197==    by 0x5C3DE7E: _gtk_marshal_VOID__OBJECT_BOXED_BOOLEAN_BOOLEANv (gtkmarshalers.c:5027)
==26197==    by 0x7BCC535: _g_closure_invoke_va (gclosure.c:867)
==26197==    by 0x7BE74B3: g_signal_emit_valist (gsignal.c:3300)
==26197==    by 0x7BE7B1E: g_signal_emit (gsignal.c:3447)
==26197==    by 0x5B3E1E9: gtk_cell_area_apply_attributes (gtkcellarea.c:2373)
==26197== 
```
So apparently, for this case, in fm_path_entry_completion_render_func(),
priv->typed_basename_len is larger than model_file_name_len.

Although currently, to begin with, I don't know if the case 
priv->typed_basename_len > model_file_name_len is expected, the proposal patch
fixes (or makes workaround for) this segv.
 