### PR TITLE
Do not save thumbnails generated from the thumbnail cache directory

### DIFF
--- a/src/base/fm-thumbnail-loader.c
+++ b/src/base/fm-thumbnail-loader.c
@@ -869,6 +869,12 @@ static GObject* scale_pix(GObject* ori_pix, int size)
 /* in thread */
 static void save_thumbnail_to_disk(ThumbnailTask* task, GObject* pix, const char* path)
 {
+    /* do not save thumbnails generated in thumbail cache directory
+     * (prevents runaway thumbnailing when browsing thumbail cache directory) */
+    if(strncmp(path,thumb_dir,strlen(thumb_dir)) == 0)
+    {
+        return;
+    }
     /* save the generated thumbnail to disk */
     char* tmpfile = g_strconcat(path, ".XXXXXX", NULL);
     gint fd;


### PR DESCRIPTION
When browsing to the directory containing the thumbnails cache (typically ~/.thumbnails), and thumbnails are active, new thumbnails are generated for the cached files. The new thumbnails are created in the same directory, and they trigger the creation of even more thumbnails in a runaway process.
This PR still allows the thumbnails in that directory to be created and displayed, but does not save them on disk.