### PR TITLE
Copy, move and delete thumbnails

### DIFF
--- a/src/base/fm-thumbnail-loader.h
+++ b/src/base/fm-thumbnail-loader.h
@@ -102,6 +102,20 @@ struct _FmThumbnailLoaderBackend {
 gboolean fm_thumbnail_loader_set_backend(FmThumbnailLoaderBackend* _backend)
                                 __attribute__((warn_unused_result,nonnull(1)));
 
+typedef enum
+{
+    LOAD_NORMAL = 1 << 0, /* need to load normal thumbnail */
+    LOAD_LARGE = 1 << 1, /* need to load large thumbnail */
+    GENERATE_NORMAL = 1 << 2, /* need to regenerated normal thumbnail */
+    GENERATE_LARGE = 1 << 3, /* need to regenerated large thumbnail */
+}ThumbnailTaskFlags;
+
+static gchar thumbnails_path[] = ".thumbnails";
+static gchar thumbnails_normal_path[] = "normal";
+static gchar thumbnails_large_path[] = "large";
+static gchar thumbnails_empty_basename[] = "00000000000000000000000000000000.png";
+void get_thumbnail_paths( gchar* src_uri, gchar* dst_normal, gchar* dst_large, ThumbnailTaskFlags flags);
+
 G_END_DECLS
 
 #endif /* __FM_THUMBNAIL_LOADER_H__ */

--- a/src/job/fm-file-ops-job-change-attr.c
+++ b/src/job/fm-file-ops-job-change-attr.c
@@ -29,6 +29,8 @@
 
 #include "fm-file-ops-job-change-attr.h"
 #include "fm-folder.h"
+#include "fm-utils.h"
+#include "../base/fm-thumbnail-loader.h"
 
 static const char query[] =  G_FILE_ATTRIBUTE_STANDARD_TYPE","
                                G_FILE_ATTRIBUTE_STANDARD_NAME","
@@ -153,6 +155,38 @@ _retry_disp_name:
         }
         else
         {
+            /* move thumbnail, if existing */
+            if(renamed != NULL && g_file_is_native(gf))
+            {
+                gchar* thumb_dir = g_build_filename(fm_get_home_dir(), thumbnails_path, NULL);
+                gchar* src_path_normal = g_build_filename(thumb_dir, thumbnails_normal_path, thumbnails_empty_basename, NULL);
+                gchar* src_path_large = g_build_filename(thumb_dir, thumbnails_large_path, thumbnails_empty_basename, NULL);
+                gchar* dest_path_normal = g_build_filename(thumb_dir, thumbnails_normal_path, thumbnails_empty_basename, NULL);
+                gchar* dest_path_large = g_build_filename(thumb_dir, thumbnails_large_path, thumbnails_empty_basename, NULL);
+                gchar* src_uri = g_file_get_uri(gf);
+                gchar* dest_uri = g_file_get_uri(renamed);
+                ThumbnailTaskFlags flags = LOAD_NORMAL | LOAD_LARGE;
+                get_thumbnail_paths( src_uri, src_path_normal, src_path_large, flags);
+                get_thumbnail_paths( dest_uri, dest_path_normal, dest_path_large, flags);
+                GFile* src_normal = g_file_new_for_path(src_path_normal);
+                GFile* src_large = g_file_new_for_path(src_path_large);
+                GFile* dest_normal = g_file_new_for_path(dest_path_normal);
+                GFile* dest_large = g_file_new_for_path(dest_path_large);
+                g_file_copy (src_normal, dest_normal, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, NULL);
+                g_file_copy (src_large, dest_large, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, NULL);
+                g_free(thumb_dir);
+                g_free(src_path_normal);
+                g_free(src_path_large);
+                g_free(dest_path_normal);
+                g_free(dest_path_large);
+                g_free(src_uri);
+                g_free(dest_uri);
+                g_object_unref(src_normal);
+                g_object_unref(src_large);
+                g_object_unref(dest_normal);
+                g_object_unref(dest_large);
+            }
+
             g_object_unref(renamed);
             changed = TRUE;
         }

--- a/src/job/fm-file-ops-job-xfer.c
+++ b/src/job/fm-file-ops-job-xfer.c
@@ -34,6 +34,7 @@
 #include <unistd.h>
 #include "fm-utils.h"
 #include <glib/gi18n-lib.h>
+#include "../base/fm-thumbnail-loader.h"
 
 static const char query[]=
     G_FILE_ATTRIBUTE_STANDARD_TYPE","
@@ -746,6 +747,39 @@ gboolean _fm_file_ops_job_copy_run(FmFileOpsJob* job)
         g_free(tmp_basename);
         if(!_fm_file_ops_job_copy_file(job, src, NULL, dest, NULL, df))
             ret = FALSE;
+
+        /* copy thumbnails, if existing */
+        if(ret == TRUE && g_file_is_native(src) && g_file_is_native(dest))
+        {
+            gchar* thumb_dir = g_build_filename(fm_get_home_dir(), thumbnails_path, NULL);
+            gchar* src_path_normal = g_build_filename(thumb_dir, thumbnails_normal_path, thumbnails_empty_basename, NULL);
+            gchar* src_path_large = g_build_filename(thumb_dir, thumbnails_large_path, thumbnails_empty_basename, NULL);
+            gchar* src_uri = g_file_get_uri(src);
+            gchar* dest_path_normal = g_build_filename(thumb_dir, thumbnails_normal_path, thumbnails_empty_basename, NULL);
+            gchar* dest_path_large = g_build_filename(thumb_dir, thumbnails_large_path, thumbnails_empty_basename, NULL);
+            gchar* dest_uri = g_file_get_uri(dest);
+            ThumbnailTaskFlags flags = LOAD_NORMAL | LOAD_LARGE;
+            get_thumbnail_paths( src_uri, src_path_normal, src_path_large, flags);
+            get_thumbnail_paths( dest_uri, dest_path_normal, dest_path_large, flags);
+            GFile* src_normal = g_file_new_for_path(src_path_normal);
+            GFile* src_large = g_file_new_for_path(src_path_large);
+            GFile* dest_normal = g_file_new_for_path(dest_path_normal);
+            GFile* dest_large = g_file_new_for_path(dest_path_large);
+            g_file_copy (src_normal, dest_normal, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, NULL);
+            g_file_copy (src_large, dest_large, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, NULL);
+            g_free(thumb_dir);
+            g_free(src_path_normal);
+            g_free(src_path_large);
+            g_free(src_uri);
+            g_free(dest_path_normal);
+            g_free(dest_path_large);
+            g_free(dest_uri);
+            g_object_unref(src_normal);
+            g_object_unref(src_large);
+            g_object_unref(dest_normal);
+            g_object_unref(dest_large);
+        }
+
         g_object_unref(src);
         g_object_unref(dest);
     }
@@ -870,6 +904,39 @@ _retry_query_dest_info:
 
         if(!_fm_file_ops_job_move_file(job, src, NULL, dest, path, sf, df))
             ret = FALSE;
+
+        /* move thumbnails, if existing */
+        if(ret == TRUE && g_file_is_native(src) && g_file_is_native(dest))
+        {
+            gchar* thumb_dir = g_build_filename(fm_get_home_dir(), thumbnails_path, NULL);
+            gchar* src_path_normal = g_build_filename(thumb_dir, thumbnails_normal_path, thumbnails_empty_basename, NULL);
+            gchar* src_path_large = g_build_filename(thumb_dir, thumbnails_large_path, thumbnails_empty_basename, NULL);
+            gchar* src_uri = g_file_get_uri(src);
+            gchar* dest_path_normal = g_build_filename(thumb_dir, thumbnails_normal_path, thumbnails_empty_basename, NULL);
+            gchar* dest_path_large = g_build_filename(thumb_dir, thumbnails_large_path, thumbnails_empty_basename, NULL);
+            gchar* dest_uri = g_file_get_uri(dest);
+            ThumbnailTaskFlags flags = LOAD_NORMAL | LOAD_LARGE;
+            get_thumbnail_paths( src_uri, src_path_normal, src_path_large, flags);
+            get_thumbnail_paths( dest_uri, dest_path_normal, dest_path_large, flags);
+            GFile* src_normal = g_file_new_for_path(src_path_normal);
+            GFile* src_large = g_file_new_for_path(src_path_large);
+            GFile* dest_normal = g_file_new_for_path(dest_path_normal);
+            GFile* dest_large = g_file_new_for_path(dest_path_large);
+            g_file_move (src_normal, dest_normal, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, NULL);
+            g_file_move (src_large, dest_large, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, NULL);
+            g_free(thumb_dir);
+            g_free(src_path_normal);
+            g_free(src_path_large);
+            g_free(src_uri);
+            g_free(dest_path_normal);
+            g_free(dest_path_large);
+            g_free(dest_uri);
+            g_object_unref(src_normal);
+            g_object_unref(src_large);
+            g_object_unref(dest_normal);
+            g_object_unref(dest_large);
+        }
+
         g_object_unref(src);
         g_object_unref(dest);
 


### PR DESCRIPTION
When files are copied, moved or deleted, their thumbnails are re-generated from scratch (which can be CPU- or disk-intensive) and/or left behind without being useful anymore (taking up disk space).
This PR applies the copy/move/delete operations to thumbnails as well (if they exist), solving these problems.