### PR TITLE
Add display of data transferred to progress dialog

### DIFF
--- a/data/ui/progress.glade
+++ b/data/ui/progress.glade
@@ -182,6 +182,37 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkLabel" id="data_transferred_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Data transferred:&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">data_transferred</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"></property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="data_transferred">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
+                    <property name="y_options"></property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkLabel" id="remaining_time_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -192,8 +223,8 @@
                     <property name="mnemonic_widget">remaining_time</property>
                   </object>
                   <packing>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="x_options">GTK_FILL</property>
                     <property name="y_options"></property>
                   </packing>
@@ -207,8 +238,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="y_options"></property>
                   </packing>
                 </child>

--- a/src/gtk/fm-progress-dlg.c
+++ b/src/gtk/fm-progress-dlg.c
@@ -34,7 +34,9 @@
 #endif
 
 #include "fm-progress-dlg.h"
+#include "fm-config.h"
 #include "fm-gtk-utils.h"
+#include "fm-utils.h"
 #include <glib/gi18n-lib.h>
 
 #define SHOW_DLG_DELAY  1000
@@ -60,6 +62,8 @@ struct _FmProgressDisplay
     GtkWidget* dest;
     GtkLabel* current;
     GtkProgressBar* progress;
+    GtkLabel* data_transferred;
+    GtkLabel* data_transferred_label;
     GtkLabel* remaining_time;
     GtkLabel *remaining_time_label;
     GtkWidget* error_pane;
@@ -75,6 +79,8 @@ struct _FmProgressDisplay
     const char *op_text;
     char* cur_file;
     char* old_cur_file;
+    goffset data_transferred_size;
+    goffset data_total_size;
     guint percent;
 
     guint delay_timeout;
@@ -428,6 +434,10 @@ static gboolean on_update_dlg(gpointer user_data)
     FmProgressDisplay* data = (FmProgressDisplay*)user_data;
     gdouble elapsed;
 
+    char* data_transferred_str;
+    char trans_size_str[128];
+    char total_size_str[128];
+
     if (g_source_is_destroyed(g_main_current_source()) || data->dlg == NULL)
         return FALSE;
     data->update_timeout = 0;
@@ -444,6 +454,15 @@ static gboolean on_update_dlg(gpointer user_data)
     g_string_printf(data->str, "%d %%", data->percent);
     gtk_progress_bar_set_fraction(data->progress, (gdouble)data->percent/100);
     gtk_progress_bar_set_text(data->progress, data->str->str);
+
+    /* display the amount of data transferred */
+    fm_file_size_to_str(trans_size_str, sizeof(trans_size_str),
+        data->data_transferred_size, fm_config->si_unit);
+    fm_file_size_to_str(total_size_str, sizeof(total_size_str),
+        data->data_total_size, fm_config->si_unit);
+    data_transferred_str = g_strdup_printf("%s / %s", trans_size_str, total_size_str);
+    gtk_label_set_text(data->data_transferred, data_transferred_str);
+    g_free(data_transferred_str);
 
     elapsed = g_timer_elapsed(data->timer, NULL);
     if(elapsed >= 0.5 && data->percent > 0)
@@ -485,6 +504,8 @@ static void on_cur_file(FmFileOpsJob* job, const char* cur_file, FmProgressDispl
 
 static void on_percent(FmFileOpsJob* job, guint percent, FmProgressDisplay* data)
 {
+    data->data_transferred_size = job->finished;
+    data->data_total_size = job->total;
     data->percent = percent;
     if(data->dlg && data->update_timeout == 0)
         data->update_timeout = gdk_threads_add_timeout(500, on_update_dlg, data);
@@ -532,6 +553,8 @@ static gboolean _on_show_dlg(gpointer user_data)
     data->progress = GTK_PROGRESS_BAR(gtk_builder_get_object(builder, "progress"));
     data->error_pane = (GtkWidget*)gtk_builder_get_object(builder, "error_pane");
     data->error_msg = GTK_TEXT_VIEW(gtk_builder_get_object(builder, "error_msg"));
+    data->data_transferred = GTK_LABEL(gtk_builder_get_object(builder, "data_transferred"));
+    data->data_transferred_label = GTK_LABEL(gtk_builder_get_object(builder, "data_transferred_label"));
     data->remaining_time = GTK_LABEL(gtk_builder_get_object(builder, "remaining_time"));
     data->remaining_time_label = GTK_LABEL(gtk_builder_get_object(builder, "remaining_time_label"));
     data->cancel = GTK_BUTTON(gtk_builder_get_object(builder, "cancel"));


### PR DESCRIPTION
This pull request adds a "Data transferred" field to the progress dialog that shows how much data is being transferred in the current operation:

![screenshot_20171012_231729](https://user-images.githubusercontent.com/1253444/31532690-a189850e-afa3-11e7-8727-dc84e3489ca5.png)

This helps give the user a sense of the speed at which the operation is progressing.