### PR TITLE
Adding file comparison attributes

### DIFF
--- a/src/gtk/fm-progress-dlg.c
+++ b/src/gtk/fm-progress-dlg.c
@@ -166,6 +166,8 @@ static gint on_ask_rename(FmFileOpsJob* job, FmFileInfo* src, FmFileInfo* dest, 
     GtkLabel *src_fi, *dest_fi;
     GtkEntry *filename;
     GtkToggleButton *apply_all;
+    char* comparedate;
+    char* comparesize;
     char* tmp;
     const char* disp_size;
     FmPath* path;
@@ -200,18 +202,34 @@ static gint on_ask_rename(FmFileOpsJob* job, FmFileInfo* src, FmFileInfo* dest, 
     gtk_window_set_transient_for(GTK_WINDOW(dlg), GTK_WINDOW(data->dlg));
 
     gtk_image_set_from_gicon(src_icon, G_ICON(icon), GTK_ICON_SIZE_DIALOG);
+    if (fm_file_info_get_mtime(src) > fm_file_info_get_mtime(dest))
+        comparedate = _("newer");
+    else
+    if (fm_file_info_get_mtime(src) < fm_file_info_get_mtime(dest))
+        comparedate = _("older");
+    else
+    if (fm_file_info_get_mtime(src) == fm_file_info_get_mtime(dest))
+        comparedate = _("same date/time");
     disp_size = fm_file_info_get_disp_size(src);
     if(disp_size)
     {
-        tmp = g_strdup_printf(_("Type: %s\nSize: %s\nModified: %s"),
-                              fm_file_info_get_desc(src), disp_size,
-                              fm_file_info_get_disp_mtime(src));
+        if (fm_file_info_get_size(src) > fm_file_info_get_size(dest))
+            comparesize = _("larger");
+        else
+        if (fm_file_info_get_size(src) < fm_file_info_get_size(dest))
+            comparesize = _("less");
+        else
+        if (fm_file_info_get_size(src) == fm_file_info_get_size(dest))
+            comparesize = _("same size");
+        tmp = g_strdup_printf(_("Type: %s\nSize: %s (%s)\nModified: %s (%s)"),
+                              fm_file_info_get_desc(src), disp_size, comparesize,
+                              fm_file_info_get_disp_mtime(src), comparedate);
     }
     else
     {
-        tmp = g_strdup_printf(_("Type: %s\nModified: %s"),
+        tmp = g_strdup_printf(_("Type: %s\nModified: %s (%s)"),
                               fm_file_info_get_desc(src),
-                              fm_file_info_get_disp_mtime(src));
+                              fm_file_info_get_disp_mtime(src), comparedate);
     }
 
     gtk_label_set_text(src_fi, tmp);


### PR DESCRIPTION
This PR adds comparison of file size and date/time when replacing and shows it in the window.
It's updated idea from Windows 7:
![0](https://user-images.githubusercontent.com/24421310/34458389-f66f752a-ede1-11e7-8e6a-61a95a6bab31.gif)
Here is some screenshots of this PR:
![1](https://user-images.githubusercontent.com/24421310/34458398-4d23ac88-ede2-11e7-8c71-8a97b74d2182.png)
![2](https://user-images.githubusercontent.com/24421310/34458400-4fd48eca-ede2-11e7-820d-8a2eec23a531.png)
![3](https://user-images.githubusercontent.com/24421310/34458403-5361d160-ede2-11e7-923b-b70eb462bc1b.png)