### PR TITLE
Protect fileinfo job from dirlist race

### DIFF
--- a/src/base/fm-folder.c
+++ b/src/base/fm-folder.c
@@ -397,7 +397,8 @@ static void on_file_info_job_finished(FmFileInfoJob* job, FmFolder* folder)
             FmFileInfo* fi = (FmFileInfo*)l->data;
             FmPath* path = fm_file_info_get_path(fi);
             GList* l2;
-            if (path == fm_file_info_get_path(folder->dir_fi))
+            /* Careful: this can race with the dirlist job. */
+            if (folder->dir_fi && path == fm_file_info_get_path(folder->dir_fi))
                 /* update for folder itself, also see FIXME below! */
                 fm_file_info_update(folder->dir_fi, fi);
             else if ((l2 = _fm_folder_get_file_by_path(folder, path)))


### PR DESCRIPTION
If the dirlist job takes a long time to complete, and in the meantime
some event causes a fileinfo job to be kicked off and completed,
folder->dir_fi can be accessed while still NULL.

I added some debug output to demonstrate the sequence of operations in a failed run:
```
** (pcmanfm:353): DEBUG: 22:43:13.950: folder reload nulling dir_fi
** (pcmanfm:353): DEBUG: 22:43:13.964: reactivated gestures to page 0
** (pcmanfm:353): DEBUG: 22:43:13.968: reactivated gestures to page 0

(pcmanfm:353): IBUS-WARNING **: 22:43:13.983: Unable to connect to ibus: Could not connect: Connection refused
** (pcmanfm:353): DEBUG: 22:43:14.176: FmJob error: No such file or directory
** (pcmanfm:353): DEBUG: 22:43:14.179: FmJob error: /home/nemesis/Documents: No such file or directory
** (pcmanfm:353): DEBUG: 22:43:14.179: folder: on_idle() started
** (pcmanfm:353): DEBUG: 22:43:14.180: folder: on_idle() done
** (pcmanfm:353): DEBUG: 22:43:14.180: FmJob error: /home/nemesis/Pictures: No such file or directory
** (pcmanfm:353): DEBUG: 22:43:14.696: folder: on_idle() started
** (pcmanfm:353): DEBUG: 22:43:14.697: folder: on_idle() done
** (pcmanfm:353): DEBUG: 22:43:14.697: fileinfo job finishing
Segmentation fault (core dumped)
```
and a successful run:
```
** (pcmanfm:376): DEBUG: 22:43:18.183: folder reload nulling dir_fi
** (pcmanfm:376): DEBUG: 22:43:18.276: FmJob error: No such file or directory
** (pcmanfm:376): DEBUG: 22:43:18.276: FmJob error: /home/nemesis/Documents: No such file or directory
** (pcmanfm:376): DEBUG: 22:43:18.276: FmJob error: /home/nemesis/Pictures: No such file or directory
** (pcmanfm:376): DEBUG: 22:43:18.319: reactivated gestures to page 0
** (pcmanfm:376): DEBUG: 22:43:18.324: reactivated gestures to page 0

(pcmanfm:376): IBUS-WARNING **: 22:43:18.326: Unable to connect to ibus: Could not connect: Connection refused
** (pcmanfm:376): DEBUG: 22:43:20.413: folder->dir_fi is safely set
** (pcmanfm:376): DEBUG: 22:43:20.484: dirlist job finished
** (pcmanfm:376): DEBUG: 22:43:21.109: unable to load icon . GThemedIcon application-x-raw-disk-image application-x-generic
** (pcmanfm:376): DEBUG: 22:43:21.395: unable to load icon . GThemedIcon application-x-apple-diskimage application-x-generic
** (pcmanfm:376): DEBUG: 22:43:21.409: unable to load icon . GThemedIcon application-x-trash application-x-generic
** (pcmanfm:376): DEBUG: 22:43:21.423: unable to load icon . GThemedIcon application-x-core application-x-generic
** (pcmanfm:376): DEBUG: 22:43:21.959: folder: on_idle() started
** (pcmanfm:376): DEBUG: 22:43:21.959: folder: on_idle() done
** (pcmanfm:376): DEBUG: 22:43:21.961: fileinfo job finishing
** (pcmanfm:376): DEBUG: 22:43:21.961: fileinfo job finished
```

After this patch, all sequences are successful:
```
** (pcmanfm:3392): DEBUG: 23:02:06.294: folder reload nulling dir_fi
** (pcmanfm:3392): DEBUG: 23:02:06.357: reactivated gestures to page 0
** (pcmanfm:3392): DEBUG: 23:02:06.394: reactivated gestures to page 0

(pcmanfm:3392): IBUS-WARNING **: 23:02:06.413: Unable to connect to ibus: Could not connect: Connection refused
** (pcmanfm:3392): DEBUG: 23:02:06.439: FmJob error: No such file or directory
** (pcmanfm:3392): DEBUG: 23:02:06.439: FmJob error: /home/nemesis/Documents: No such file or directory
** (pcmanfm:3392): DEBUG: 23:02:06.441: FmJob error: /home/nemesis/Pictures: No such file or directory
** (pcmanfm:3392): DEBUG: 23:02:06.774: folder: on_idle() started
** (pcmanfm:3392): DEBUG: 23:02:06.774: folder: on_idle() done
** (pcmanfm:3392): DEBUG: 23:02:07.114: folder: on_idle() started
** (pcmanfm:3392): DEBUG: 23:02:07.114: folder: on_idle() done
** (pcmanfm:3392): DEBUG: 23:02:07.121: folder: on_idle() started
** (pcmanfm:3392): DEBUG: 23:02:07.121: folder: on_idle() done
** (pcmanfm:3392): DEBUG: 23:02:07.122: fileinfo job finishing
** (pcmanfm:3392): DEBUG: 23:02:07.123: fileinfo job finished
** (pcmanfm:3392): DEBUG: 23:02:07.131: folder: on_idle() started
** (pcmanfm:3392): DEBUG: 23:02:07.131: folder: on_idle() done
** (pcmanfm:3392): DEBUG: 23:02:07.195: folder->dir_fi is safely set
** (pcmanfm:3392): DEBUG: 23:02:07.218: dirlist job finished
** (pcmanfm:3392): DEBUG: 23:02:07.258: unable to load icon . GThemedIcon application-x-raw-disk-image application-x-generic
** (pcmanfm:3392): DEBUG: 23:02:07.315: unable to load icon . GThemedIcon application-x-apple-diskimage application-x-generic
** (pcmanfm:3392): DEBUG: 23:02:07.325: unable to load icon . GThemedIcon application-x-trash application-x-generic
** (pcmanfm:3392): DEBUG: 23:02:07.344: unable to load icon . GThemedIcon application-x-core application-x-generic
** (pcmanfm:3392): DEBUG: 23:02:07.508: folder: on_idle() started
** (pcmanfm:3392): DEBUG: 23:02:07.508: folder: on_idle() done
** (pcmanfm:3392): DEBUG: 23:02:07.549: fileinfo job finishing
** (pcmanfm:3392): DEBUG: 23:02:07.549: fileinfo job finished
``