### PR TITLE
Enable mid-string search in PCManFM.

### DIFF
--- a/src/gtk/exo/exo-icon-view.c
+++ b/src/gtk/exo/exo-icon-view.c
@@ -453,7 +453,7 @@ static void     exo_icon_view_search_preedit_changed    (GtkIMContext   *im_cont
 #endif
 static gboolean exo_icon_view_search_start              (ExoIconView    *icon_view,
                                                          gboolean        keybinding);
-static gboolean exo_icon_view_search_equal_func         (GtkTreeModel   *model,
+gboolean exo_icon_view_search_equal_func         (GtkTreeModel   *model,
                                                          gint            column,
                                                          const gchar    *key,
                                                          GtkTreeIter    *iter,
@@ -8935,7 +8935,7 @@ exo_icon_view_search_start (ExoIconView *icon_view,
 
 
 
-static gboolean
+gboolean
 exo_icon_view_search_equal_func (GtkTreeModel *model,
                                  gint          column,
                                  const gchar  *key,
@@ -8982,7 +8982,7 @@ exo_icon_view_search_equal_func (GtkTreeModel *model,
       case_normalized_key = g_utf8_casefold (normalized_key, -1);
 
       /* compare the casefolded strings */
-      if (strncmp (case_normalized_key, case_normalized_string, strlen (case_normalized_key)) == 0)
+      if (strstr (case_normalized_string, case_normalized_key) != 0)
         retval = FALSE;
     }
 

--- a/src/gtk/exo/exo-tree-view.c
+++ b/src/gtk/exo/exo-tree-view.c
@@ -224,10 +224,19 @@ exo_tree_view_class_init (ExoTreeViewClass *klass)
 }
 
 
+gboolean
+exo_icon_view_search_equal_func (GtkTreeModel *model,
+                 gint     column,
+                 const gchar *key,
+                 GtkTreeIter *iter,
+                 gpointer   user_data);
+
 
 static void
 exo_tree_view_init (ExoTreeView *tree_view)
 {
+  gtk_tree_view_set_search_equal_func(&tree_view->__parent__, exo_icon_view_search_equal_func, 0, 0);
+
   /* grab a pointer on the private data */
   tree_view->priv = EXO_TREE_VIEW_GET_PRIVATE (tree_view);
   tree_view->priv->single_click_timeout_id = -1;


### PR DESCRIPTION
This change will enable users to find files to typing just part of their name - all files containing the string will be matched, not just those starting with it.

Example:
[Demo showing the search](https://raw.githubusercontent.com/sashoalm/libfm/master/demo.gif)