### PR TITLE
Fix memory access error if home path == desktop path

### DIFF
--- a/src/base/fm-path.c
+++ b/src/base/fm-path.c
@@ -1291,7 +1291,7 @@ void _fm_path_init()
     }
     else
     {
-        name = desktop_dir + home_len + 1; /* skip home_path dir part / */
+        name = desktop_dir + home_len; /* skip home_path dir part / */
         while (*name == '/') name++; /* skip extra / if any */
         if (*name == '\0')
             name = "Desktop"; /* fallback: never use home_path as desktop_path */


### PR DESCRIPTION
Fixed a problem where if the home directory path and desktop directory path are
the same, desktop path would get corrupted. Without the fix, libfm will read
garbage from memory and treat it as a desktop path.