### PR TITLE
"Open with" menu when middle-clicking on files

### DIFF
--- a/src/gtk/fm-file-menu.h
+++ b/src/gtk/fm-file-menu.h
@@ -33,6 +33,7 @@ G_BEGIN_DECLS
 typedef struct _FmFileMenu FmFileMenu;
 
 FmFileMenu* fm_file_menu_new_for_file(GtkWindow* parent, FmFileInfo* fi, FmPath* cwd, gboolean auto_destroy);
+FmFileMenu* fm_app_menu_new_for_files(GtkWindow* parent, FmFileInfoList* files, FmPath* cwd, gboolean auto_destroy);
 FmFileMenu* fm_file_menu_new_for_files(GtkWindow* parent, FmFileInfoList* files, FmPath* cwd, gboolean auto_destroy);
 void fm_file_menu_destroy(FmFileMenu* menu);
 


### PR DESCRIPTION
A middle-click on a directory opens it in a new tab, but a middle-click on any other file currently does nothing. I find it convenient to use it as a shortcut for the "open with" menu.
Currently only works for the GTK version. If there is interest in merging, i could look into QT as well.