### PR TITLE
Also treat /usr/local/share/ as trusted for *.desktop files

### DIFF
--- a/src/base/fm-file-info.c
+++ b/src/base/fm-file-info.c
@@ -1393,7 +1393,8 @@ gboolean fm_file_info_is_executable_type(FmFileInfo* fi)
                    which may be considered as a safe desktop entry path
                    then check if that is a shortcut to a native file
                    otherwise it is a link to a file under menu:// */
-                if (!g_str_has_prefix(fi->target, "/usr/share/"))
+                if (!g_str_has_prefix(fi->target, "/usr/share/") &&
+                        !g_str_has_prefix(fi->target, "/usr/local/share/"))
                 {
                     FmPath *target = fm_path_new_for_str(fi->target);
                     gboolean is_native = fm_path_is_native(target);


### PR DESCRIPTION
lxde/libfm#21 added a security measure to prevent auto-execution of
possibly untrusted `*.desktop` files, with a hard-coded exception for
.desktop files found under `/usr/share` (e.g. `/usr/share/applications`)
as it is under system control, to mitigate user inconvenience.

This effectively broke LXDE under platforms that default to a different
path for packages/software installed by the (privileged) system
administrator, as now every interaction prompts users to choose between
launching or viewing the `.desktop` target in question.

This patch adds `/usr/local/share` to that list of exceptions, which is
the default location for system-controlled, non-1st-party applications,
on many platforms/distributions, such as FreeBSD.

(Obviously this is all with regards to `/usr/local/share` and not
`$HOME/.local/share`)