### PR TITLE
Fix value for amount of data transferred

### DIFF
--- a/src/gtk/fm-progress-dlg.c
+++ b/src/gtk/fm-progress-dlg.c
@@ -506,7 +506,7 @@ static void on_cur_file(FmFileOpsJob* job, const char* cur_file, FmProgressDispl
 
 static void on_percent(FmFileOpsJob* job, guint percent, FmProgressDisplay* data)
 {
-    data->data_transferred_size = job->finished;
+    data->data_transferred_size = job->finished + job->current_file_finished;
     data->data_total_size = job->total;
     data->percent = percent;
     if(data->dlg && data->update_timeout == 0)


### PR DESCRIPTION
When a large single file is being transferred, the value for the amount of data transferred shown on the progress dialog stays at 0 bytes. This is because there are two values provided from a file operation - the number of bytes transferred in all previous completed files, and the number of bytes transferred in the current file. These values need to be added together to compare correctly against the total - at present, only the number of bytes transferred in previous completed files is shown.