### PR TITLE
Don't set $DISPLAY

### DIFF
--- a/src/base/fm-action.c
+++ b/src/base/fm-action.c
@@ -661,15 +661,12 @@ static GIcon * _fm_action_get_icon(GAppInfo *appinfo)
 
 struct ChildSetup
 {
-    char *display;
     char *sn_id;
 };
 
 static void child_setup(gpointer user_data)
 {
     struct ChildSetup* data = (struct ChildSetup*)user_data;
-    if (data->display)
-        g_setenv("DISPLAY", data->display, TRUE);
     if (data->sn_id)
         g_setenv("DESKTOP_STARTUP_ID", data->sn_id, TRUE);
 }
@@ -722,7 +719,6 @@ static gboolean _do_launch(FmAction *action, GAppLaunchContext *launch_context,
         GList *launched_files, *l;
         struct ChildSetup data;
 
-        data.display = NULL;
         data.sn_id = NULL;
         if (launch_context)
         {
@@ -732,9 +728,6 @@ static gboolean _do_launch(FmAction *action, GAppLaunchContext *launch_context,
                 launched_files = g_list_prepend(launched_files,
                                 fm_path_to_gfile(fm_file_info_get_path(l->data)));
             launched_files = g_list_reverse(launched_files);
-            data.display = g_app_launch_context_get_display(launch_context,
-                                                            G_APP_INFO(action),
-                                                            launched_files);
             if (action->use_sn)
                 data.sn_id = g_app_launch_context_get_startup_notify_id(launch_context,
                                                                         G_APP_INFO(action),

--- a/src/base/fm-app-info.c
+++ b/src/base/fm-app-info.c
@@ -214,7 +214,6 @@ static char* expand_exec_macros(GAppInfo* app, const char* full_desktop_path,
 
 struct ChildSetup
 {
-    char* display;
     char* sn_id;
     pid_t pgid;
 };
@@ -222,8 +221,6 @@ struct ChildSetup
 static void child_setup(gpointer user_data)
 {
     struct ChildSetup* data = (struct ChildSetup*)user_data;
-    if(data->display)
-        g_setenv ("DISPLAY", data->display, TRUE);
     if(data->sn_id)
         g_setenv ("DESKTOP_STARTUP_ID", data->sn_id, TRUE);
     /* Move child to grandparent group so it will not die with parent */
@@ -340,7 +337,6 @@ static gboolean do_launch(GAppInfo* appinfo, const char* full_desktop_path,
             }
             else
                 use_sn = FALSE;
-            data.display = g_app_launch_context_get_display(ctx, appinfo, gfiles);
 
             if(use_sn)
                 data.sn_id = g_app_launch_context_get_startup_notify_id(ctx, appinfo, gfiles);
@@ -348,10 +344,8 @@ static gboolean do_launch(GAppInfo* appinfo, const char* full_desktop_path,
                 data.sn_id = NULL;
         }
         else
-        {
-            data.display = NULL;
             data.sn_id = NULL;
-        }
+
         g_debug("sn_id = %s", data.sn_id);
 
         if(G_LIKELY(kf))
@@ -372,7 +366,6 @@ static gboolean do_launch(GAppInfo* appinfo, const char* full_desktop_path,
             g_app_launch_context_launch_failed(ctx, data.sn_id);
 
         g_free(path);
-        g_free(data.display);
         g_free(data.sn_id);
 
         g_strfreev(argv);


### PR DESCRIPTION
`g_app_launch_context_get_display` returns `$DISPLAY` on X, but `$WAYLAND_DISPLAY` on Wayland. When then setting `$DISPLAY` to what `g_app_launch_context_get_display` returns on Wayland, it will cause it to not be able to launch X-only apps, because `$DISPLAY` will then contain an invalid X display (namely the name of the Wayland socket).

Setting `$DISPLAY` is unnecessary anyway as far as I could tell, because the launched app will inherit the environment variables from its parent. In order for e.g. PCManFM to be launched on X, it will need `$DISPLAY` to be set, so it will also give the correct `$DISPLAY` to the launched app.