### PR TITLE
Create thumbnails according to the XDG Base Directory Specification

### DIFF
--- a/src/base/fm-thumbnail-loader.c
+++ b/src/base/fm-thumbnail-loader.c
@@ -746,7 +746,7 @@ guint fm_thumbnail_loader_get_size(FmThumbnailLoader* req)
 /* in main loop */
 void _fm_thumbnail_loader_init()
 {
-    thumb_dir = g_build_filename(fm_get_home_dir(), ".thumbnails", NULL);
+    thumb_dir = g_build_filename(g_get_user_cache_dir(), "thumbnails", NULL);
     hash = g_hash_table_new((GHashFunc)fm_path_hash, (GEqualFunc)fm_path_equal);
 #if !GLIB_CHECK_VERSION(2, 32, 0)
     lock_ptr = g_mutex_new();


### PR DESCRIPTION
The thumbnail directory should be created where user-specific
non-essential (cached) data should be written rather than in the
user's home directory.

This addresses github issue #57.