### PR TITLE
Fix background color with GTK3

### DIFF
--- a/src/gtk/exo/exo-icon-view.c
+++ b/src/gtk/exo/exo-icon-view.c
@@ -1878,6 +1878,16 @@ exo_icon_view_expose_event (GtkWidget      *widget,
 
   if (!gtk_cairo_should_draw_window (cr, priv->bin_window))
     return FALSE;
+
+  /* draw a background according to the css theme */
+  style = gtk_widget_get_style_context (widget);
+  gtk_style_context_save (style);
+  gtk_style_context_add_class (style, GTK_STYLE_CLASS_VIEW);
+  gtk_render_background (style, cr,
+                         0, 0,
+                         gtk_widget_get_allocated_width (widget),
+                         gtk_widget_get_allocated_height (widget));
+  gtk_style_context_restore (style);
 #endif
 
   /* don't handle expose if the layout isn't done yet; the layout
@@ -1978,10 +1988,8 @@ exo_icon_view_expose_event (GtkWidget      *widget,
 #endif
     }
 
+#if !GTK_CHECK_VERSION(3, 0, 0)
   if (G_UNLIKELY (dest_item != NULL || priv->doing_rubberband))
-#if GTK_CHECK_VERSION(3, 0, 0)
-      style = gtk_widget_get_style_context (widget);
-#else
       style = gtk_widget_get_style (widget);
 #endif
 


### PR DESCRIPTION
I tried building for gtk3, and the background color was wrong (it was the same as the toolbars - see attached picture, left side). This is how I fixed it (result on right side). I can make changes if required for merging.

![image](https://user-images.githubusercontent.com/20945263/111179462-66c52f80-85ac-11eb-8279-708154f80156.png)
