### PR TITLE
modules: fix cross-compilation

### DIFF
--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -11,7 +11,6 @@ AM_CPPFLAGS = \
 # tell libtool we compile module not library
 AM_LDFLAGS = \
 	-no-undefined -module -avoid-version -shared -export-dynamic \
-	-L$(libdir) \
 	$(GIO_LIBS)
 
 # the module should be linked only with libfm, not libfm-gtk or whatever


### PR DESCRIPTION
Do not add -L$(libdir) to AM_LDFLAGS

[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/libfm/0001-modules-fix-cross-compilation.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>