### PR TITLE
Use "g_mount_can_eject" to determine removable media

### DIFF
--- a/src/job/fm-file-ops-job-delete.c
+++ b/src/job/fm-file-ops-job-delete.c
@@ -348,7 +348,7 @@ _retry_trash:
 
             if(mnt)
             {
-                ret = g_mount_can_unmount(mnt); /* TRUE if it's removable media */
+                ret = g_mount_can_eject(mnt); /* TRUE if it's removable media */
                 g_object_unref(mnt);
                 if(ret)
                     fm_path_list_push_tail(unsupported, FM_PATH(l->data));


### PR DESCRIPTION
by using `g_mount_can_unmount`, libfm treats my secondary, permanent disks as removable and does not allow me to send to trash. by checking `g_mount_can_eject` instead, libfm properly distinguishes between real removable media and things that can simply be unmounted.