### PR TITLE
Add date-time-format option

### DIFF
--- a/src/base/fm-config.c
+++ b/src/base/fm-config.c
@@ -121,6 +121,8 @@ static void fm_config_finalize(GObject *object)
         g_free(cfg->terminal);
     if(cfg->archiver)
         g_free(cfg->archiver);
+    if(cfg->date_time_format)
+        g_free(cfg->date_time_format);
     g_strfreev(cfg->system_modules_blacklist);
     g_strfreev(cfg->modules_blacklist);
     g_strfreev(cfg->modules_whitelist);
@@ -269,6 +271,14 @@ void fm_config_load_from_key_file(FmConfig* cfg, GKeyFile* kf)
     if(cfg->archiver)
         g_free(cfg->archiver);
     cfg->archiver = g_key_file_get_string(kf, "config", "archiver", NULL);
+    if(cfg->date_time_format)
+        g_free(cfg->date_time_format);
+    cfg->date_time_format = g_key_file_get_string(kf, "config", "date_time_format", NULL);
+    if(!cfg->date_time_format) /* absence from config file causes segfault */
+    {
+        cfg->date_time_format = g_malloc(sizeof(char) * strlen(FM_CONFIG_DEFAULT_DATE_TIME_FORMAT));
+        g_stpcpy(cfg->date_time_format, FM_CONFIG_DEFAULT_DATE_TIME_FORMAT);
+    }
     fm_key_file_get_bool(kf, "config", "thumbnail_local", &cfg->thumbnail_local);
     fm_key_file_get_int(kf, "config", "thumbnail_max", &cfg->thumbnail_max);
     fm_key_file_get_bool(kf, "config", "advanced_mode", &cfg->advanced_mode);
@@ -501,6 +511,7 @@ void fm_config_save(FmConfig* cfg, const char* name)
 #endif
                 _save_config_string(str, cfg, terminal);
                 _save_config_string(str, cfg, archiver);
+                _save_config_string(str, cfg, date_time_format);
                 _save_config_string(str, cfg, format_cmd);
                 _save_config_bool(str, cfg, thumbnail_local);
                 _save_config_int(str, cfg, thumbnail_max);

--- a/src/base/fm-config.h
+++ b/src/base/fm-config.h
@@ -67,6 +67,7 @@ typedef struct _FmConfigClass       FmConfigClass;
 #define     FM_CONFIG_DEFAULT_TEMPLATE_RUN_APP  FALSE
 #define     FM_CONFIG_DEFAULT_TEMPL_TYPE_ONCE   FALSE
 #define     FM_CONFIG_DEFAULT_SHADOW_HIDDEN     FALSE
+#define     FM_CONFIG_DEFAULT_DATE_TIME_FORMAT  "%x %R"
 #define     FM_CONFIG_DEFAULT_DEFER_CONTENT_TEST FALSE
 #define     FM_CONFIG_DEFAULT_QUICK_EXEC        FALSE
 #define     FM_CONFIG_DEFAULT_SMART_DESKTOP_AUTODROP TRUE
@@ -105,6 +106,7 @@ typedef enum
  * FmConfig:
  * @terminal: command line to launch terminal emulator
  * @archiver: desktop_id of the archiver used
+ * @date_time_format: date-time format (strftime)
  * @big_icon_size: size of big icons
  * @small_icon_size: size of small icons
  * @pane_icon_size: size of side pane icons
@@ -156,6 +158,7 @@ struct _FmConfig
     /*< public >*/
     char* terminal;
     char* archiver;
+    char* date_time_format;
 
     gint big_icon_size;
     gint small_icon_size;

--- a/src/base/fm-file-info.c
+++ b/src/base/fm-file-info.c
@@ -1622,7 +1622,7 @@ const char* fm_file_info_get_disp_mtime(FmFileInfo* fi)
         {
             char buf[ 128 ];
             strftime(buf, sizeof(buf),
-                      "%x %R",
+                      fm_config->date_time_format,
                       localtime(&fi->mtime));
             fi->disp_mtime = g_strdup(buf);
         }


### PR DESCRIPTION
Currently, the format for date-time (as used in PCManFM’s ‘Modified’ column) is based on locale. The only way to change it (e.g. to ISO 8601) is to switch (or modify) the locale. Users might prefer to configure the date-time format within PCManFM Preferences.

Here is a simple manual setting, using strftime, similar to LXDE’s Digital Clock applet.