### PR TITLE
Restore ABI for libfm.so

### DIFF
--- a/src/base/fm-config.c
+++ b/src/base/fm-config.c
@@ -260,10 +260,12 @@ static void _parse_drop_default_action(GKeyFile *kf, gint *action)
 void fm_config_load_from_key_file(FmConfig* cfg, GKeyFile* kf)
 {
     char **strv;
+    gboolean bool_val;
 
     fm_key_file_get_bool(kf, "config", "use_trash", &cfg->use_trash);
     fm_key_file_get_bool(kf, "config", "single_click", &cfg->single_click);
-    fm_key_file_get_bool(kf, "config", "middle_click", &cfg->middle_click);
+    fm_key_file_get_bool(kf, "config", "middle_click", &bool_val);
+    cfg->middle_click = bool_val;
     if(cfg->single_click && cfg->middle_click)
         cfg->middle_click = FALSE;
     fm_key_file_get_int(kf, "config", "auto_selection_delay", &cfg->auto_selection_delay);
@@ -280,7 +282,8 @@ void fm_config_load_from_key_file(FmConfig* cfg, GKeyFile* kf)
     fm_key_file_get_bool(kf, "config", "advanced_mode", &cfg->advanced_mode);
     fm_key_file_get_bool(kf, "config", "si_unit", &cfg->si_unit);
     fm_key_file_get_bool(kf, "config", "force_startup_notify", &cfg->force_startup_notify);
-    fm_key_file_get_bool(kf, "config", "date_iso_8601", &cfg->date_iso_8601);
+    fm_key_file_get_bool(kf, "config", "date_iso_8601", &bool_val);
+    cfg->date_iso_8601 = bool_val;
     fm_key_file_get_bool(kf, "config", "backup_as_hidden", &cfg->backup_as_hidden);
     fm_key_file_get_bool(kf, "config", "no_usb_trash", &cfg->no_usb_trash);
     fm_key_file_get_bool(kf, "config", "no_child_non_expandable", &cfg->no_child_non_expandable);

--- a/src/base/fm-config.h
+++ b/src/base/fm-config.h
@@ -171,7 +171,6 @@ struct _FmConfig
     gint drop_default_action;
 
     gboolean single_click;
-    gboolean middle_click;
     gboolean use_trash;
     gboolean confirm_del;
     gboolean confirm_trash;
@@ -181,7 +180,6 @@ struct _FmConfig
     gboolean si_unit;
     gboolean advanced_mode;
     gboolean force_startup_notify;
-    gboolean date_iso_8601;
     gboolean backup_as_hidden;
     gboolean no_usb_trash;
     gboolean no_child_non_expandable;
@@ -215,9 +213,9 @@ struct _FmConfig
     gboolean smart_desktop_autodrop;
     gchar *saved_search;
     /*< private >*/
-    gpointer _reserved1; /* reserved space for updates until next ABI */
-    gpointer _reserved2;
-    gpointer _reserved3;
+    gintptr middle_click;
+    gintptr date_iso_8601;
+    gpointer _reserved3; /* reserved space for updates until next ABI */
     gpointer _reserved4;
     gpointer _reserved5;
     gpointer _reserved6;


### PR DESCRIPTION
The following 2 commit:
https://github.com/lxde/libfm/commit/b0545e0e7bd347dbb8001c153f8bd46718d0c852 https://github.com/lxde/libfm/commit/2854a4ce01f1e2868f2fa2f453eca5fe3fd8339c broke libfm.so ABI because this changed the size of `struct _FmConfig` .

Restore libfm.so ABI compared to before.
Fixes #104 .