### PR TITLE
FIX: function argument fix for C23 conformance

### DIFF
--- a/src/base/fm-dummy-monitor.c
+++ b/src/base/fm-dummy-monitor.c
@@ -37,7 +37,7 @@
 
 G_DEFINE_TYPE(FmDummyMonitor, fm_dummy_monitor, G_TYPE_FILE_MONITOR);
 
-static gboolean cancel()
+static gboolean cancel(GFileMonitor *)
 {
     return TRUE;
 }


### PR DESCRIPTION
C23 now regards function declaration without a parameter list as that with no parameter (i.e. having `(void)`).

Specify parameter list explicitly to make code C23 conformant.

Closes #106 .