### PR TITLE
Suppress GFileInfo related warnings

### DIFF
--- a/src/base/fm-file-info.c
+++ b/src/base/fm-file-info.c
@@ -559,14 +559,20 @@ void fm_file_info_set_from_g_file_data(FmFileInfo *fi, GFile *gf, GFileInfo *inf
 
     g_return_if_fail(fi->path);
 
-    tmp = g_file_info_get_edit_name(inf);
+    tmp = NULL;
+    if (g_file_info_has_attribute(inf, G_FILE_ATTRIBUTE_STANDARD_EDIT_NAME))
+        tmp = g_file_info_get_edit_name(inf);
     if (!tmp || strcmp(tmp, "/") == 0)
         tmp = g_file_info_get_display_name(inf);
     _fm_path_set_display_name(fi->path, tmp);
 
-    fi->size = g_file_info_get_size(inf);
+    fi->size = 0;
+    if (g_file_info_has_attribute(inf, G_FILE_ATTRIBUTE_STANDARD_SIZE))
+        fi->size = g_file_info_get_size(inf);
 
-    tmp = g_file_info_get_content_type(inf);
+    tmp = NULL;
+    if (g_file_info_has_attribute(inf, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE))
+        tmp = g_file_info_get_content_type(inf);
     if(tmp)
         fi->mime_type = fm_mime_type_from_name(tmp);
 
@@ -623,7 +629,8 @@ void fm_file_info_set_from_g_file_data(FmFileInfo *fi, GFile *gf, GFileInfo *inf
         fi->accessible = TRUE;
 
     /* special handling for symlinks */
-    if (g_file_info_get_is_symlink(inf))
+    if (g_file_info_has_attribute(inf, G_FILE_ATTRIBUTE_STANDARD_IS_SYMLINK) &&
+        g_file_info_get_is_symlink(inf))
     {
         fi->mode &= ~S_IFMT; /* reset type */
         fi->mode |= S_IFLNK; /* set type to symlink */
@@ -714,8 +721,10 @@ _file_is_symlink:
     fi->mtime = g_file_info_get_attribute_uint64(inf, G_FILE_ATTRIBUTE_TIME_MODIFIED);
     fi->atime = g_file_info_get_attribute_uint64(inf, G_FILE_ATTRIBUTE_TIME_ACCESS);
     fi->ctime = g_file_info_get_attribute_uint64(inf, G_FILE_ATTRIBUTE_TIME_CHANGED);
-    fi->hidden = g_file_info_get_is_hidden(inf);
-    fi->backup = g_file_info_get_is_backup(inf);
+    fi->hidden = (g_file_info_has_attribute(inf, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN) &&
+        g_file_info_get_is_hidden(inf));
+    fi->backup =  (g_file_info_has_attribute(inf, G_FILE_ATTRIBUTE_STANDARD_IS_BACKUP) &&
+        g_file_info_get_is_backup(inf));
     fi->name_is_changeable = TRUE; /* GVFS tends to ignore this attribute */
     fi->icon_is_changeable = fi->hidden_is_changeable = FALSE;
     if (g_file_info_has_attribute(inf, G_FILE_ATTRIBUTE_ACCESS_CAN_RENAME))

--- a/src/gtk/fm-path-entry.c
+++ b/src/gtk/fm-path-entry.c
@@ -485,7 +485,8 @@ static gboolean list_sub_dirs(GIOSchedulerJob *job, GCancellable *cancellable, g
                 GFileType type = g_file_info_get_file_type(inf);
                 if(type == G_FILE_TYPE_DIRECTORY)
                 {
-                    const char* name = g_file_info_get_edit_name(inf);
+                    const char* name = g_file_info_has_attribute(inf, G_FILE_ATTRIBUTE_STANDARD_EDIT_NAME) ?
+                        g_file_info_get_edit_name(inf) : NULL;
                     if (!name)
                         name = g_file_info_get_display_name(inf);
                     data->subdirs = g_list_prepend(data->subdirs, g_strdup(name));

--- a/src/job/fm-file-info-job.h
+++ b/src/job/fm-file-info-job.h
@@ -111,6 +111,7 @@ static inline gboolean
 _fm_file_info_job_update_fs_readonly(GFile *gf, GFileInfo *inf, GCancellable *cancellable, GError **error)
 {
     /* check if FS is R/O and set attr. into inf */
+    if (!gf) return FALSE;
     GFileInfo *fs_inf = g_file_query_filesystem_info(gf, G_FILE_ATTRIBUTE_FILESYSTEM_READONLY,
                                                      cancellable, error);
     if (fs_inf)

--- a/src/modules/vfs-search.c
+++ b/src/modules/vfs-search.c
@@ -251,7 +251,8 @@ static GFileInfo *_fm_vfs_search_enumerator_next_file(GFileEnumerator *enumerato
         }
 
         file_info = g_file_enumerator_next_file(iter->enu, cancellable, &err);
-        if(file_info && g_file_info_get_name(file_info))
+        if(file_info && g_file_info_has_attribute (file_info, G_FILE_ATTRIBUTE_STANDARD_NAME) &&
+           g_file_info_get_name(file_info))
         {
             /* check if directory itself matches criteria */
             if(fm_search_job_match_file(enu, file_info, iter->folder_path,
@@ -867,7 +868,8 @@ static gboolean fm_search_job_match_file(FmVfsSearchEnumerator * priv,
 {
     //g_print("matching file %s\n", g_file_info_get_name(info));
 
-    if(!priv->show_hidden && g_file_info_get_is_hidden(info))
+    if(!priv->show_hidden && g_file_info_has_attribute(info, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN) &&
+        g_file_info_get_is_hidden(info))
         return FALSE;
 
     if(!fm_search_job_match_filename(priv, info))

--- a/src/modules/vfs-search.c
+++ b/src/modules/vfs-search.c
@@ -266,10 +266,13 @@ static GFileInfo *_fm_vfs_search_enumerator_next_file(GFileEnumerator *enumerato
                /* SF bug #969: very possibly we get multiple instances of the
                   same file if we follow symlink to a directory
                   FIXME: make it optional? */
-               !g_file_info_get_is_symlink(file_info) &&
+               !(g_file_info_has_attribute(file_info, G_FILE_ATTRIBUTE_STANDARD_IS_SYMLINK) &&
+                 g_file_info_get_is_symlink(file_info)) &&
                g_file_info_get_file_type(file_info) == G_FILE_TYPE_DIRECTORY)
             {
-                if(enu->show_hidden || !g_file_info_get_is_hidden(file_info))
+                if(enu->show_hidden ||
+                   !(g_file_info_has_attribute(file_info, G_FILE_ATTRIBUTE_STANDARD_IS_HIDDEN) &&
+                     g_file_info_get_is_hidden(file_info)))
                 {
                     const char * name = g_file_info_get_name(file_info);
                     GFile * file = g_file_get_child(iter->folder_path, name);
@@ -829,8 +832,10 @@ static gboolean fm_search_job_match_file_type(FmVfsSearchEnumerator* priv, GFile
 
 static gboolean fm_search_job_match_size(FmVfsSearchEnumerator* priv, GFileInfo* info)
 {
-    guint64 size = g_file_info_get_size(info);
     gboolean ret = TRUE;
+    guint64 size = 0;
+    if (g_file_info_has_attribute(info, G_FILE_ATTRIBUTE_STANDARD_SIZE))
+        size = g_file_info_get_size(info);
     if(priv->min_size > 0 && size < priv->min_size)
         ret = FALSE;
     else if(priv->max_size > 0 && size > priv->max_size)


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/glib/-/issues/3068 says that when GFileInfo is created via g_file_enumerate_children then g_file_enumerator_next_file , calling g_file_info_has_attribute beforehand is always needed for standard::is-hidden or standard::content-type (or so), even if GFileQueryInfoFlags is correctly specified.

Closes #118 .