### PR TITLE
thumbnail-loader: fall back to external thumbnailers when built-in fails

### DIFF
--- a/src/base/fm-thumbnail-loader.c
+++ b/src/base/fm-thumbnail-loader.c
@@ -810,7 +810,8 @@ static void generate_thumbnails(ThumbnailTask* task)
         (fm_config->thumbnail_max == 0 ||
          fm_file_info_get_size(task->fi) <= (fm_config->thumbnail_max << 10)))
     {
-        generate_thumbnails_with_builtin(task);
+	if (!generate_thumbnails_with_builtin(task))
+	generate_thumbnails_with_thumbnailers(task);
     }
     else
         generate_thumbnails_with_thumbnailers(task);


### PR DESCRIPTION
When fm_file_info_is_image() returns TRUE (e.g. for image/x-exr, image/vnd.radiance, image/vnd.dxf), generate_thumbnails() entered the built-in path exclusively. If GdkPixbuf could not load the file, generate_thumbnails_with_builtin() returned FALSE but the return value was ignored, so external thumbnailers registered for those MIME types were never invoked.

Fix: check the return value and fall through to generate_thumbnails_with_thumbnailers() on failure.

Fixes: lxde/pcmanfm#51