### PR TITLE
g-udisks-volume: fix incorrect g_realloc and memcpy usage

### DIFF
--- a/src/udisks/g-udisks-volume.c
+++ b/src/udisks/g-udisks-volume.c
@@ -299,8 +299,8 @@ static void mount_callback(DBusGProxy *proxy, char * OUT_mount_path, GError *err
             if(!*p) /* OUT_mount_path is not in mount_paths */
             {
                 int len = g_strv_length(data->vol->dev->mount_paths);
-                data->vol->dev->mount_paths = g_realloc(data->vol->dev->mount_paths, + 2);
-                memcpy(data->vol->dev->mount_paths, data->vol->dev->mount_paths + sizeof(char*), len * sizeof(char*));
+                data->vol->dev->mount_paths = g_realloc(data->vol->dev->mount_paths, (len + 2) * sizeof(char*));
+                memmove(data->vol->dev->mount_paths + 1, data->vol->dev->mount_paths, (len + 1) * sizeof(char*));
                 data->vol->dev->mount_paths[0] = g_strdup(OUT_mount_path);
             }
         }


### PR DESCRIPTION
gcc17 -fanalyzer warns:
src/udisks/g-udisks-volume.c:302:45: warning: allocated buffer size is not a multiple of the pointee's size [CWE-131] [-Wanalyzer-allocation-size]

Actually:
1. The second argument of g_realloc: "+2" is apparently wrong: it should be `len + 2`, also should be multiplied by the size of element.
2. The direction (in other words, the first and second arguments) of memcpy is swapped. The latter line seems to be trying to prepend `OUT_mount_path` to mount_paths, so mount_paths[0] should be moved to mount_paths[1]
3. `data->vol->dev->mount_paths + sizeof(char*)` points to the `sizeof(char*)`-th element of `mount_paths` (starting at 0), which is apparently not intended: which should be 1th element (starting at 0).
4. Using `memcpy` for overwrapping region is incorrect. That should be `memmove`.
5. `len` value, which is the result of `g_strv_length`, does not count the last NULL sentinel. So to count the size of `memmove`, the last NULL sentinel must be considered.

This change fixes the above issues.