### PR TITLE
Fix segfault on search URI parameter with no value

### DIFF
--- a/src/modules/vfs-search.c
+++ b/src/modules/vfs-search.c
@@ -482,6 +482,21 @@ static void parse_search_uri(FmVfsSearchEnumerator* priv, const char* uri_str)
 
                 /* g_printf("parameter name/value: %s = %s\n", name, value); */
 
+                /* a parameter with no value (e.g. "show_hidden" instead of
+                 * "show_hidden=1") carries no information; skip it rather than
+                 * dereferencing the NULL value below */
+                if(value == NULL)
+                {
+                    g_free(name);
+                    if(sep)
+                    {
+                        params = sep + 1;
+                        continue;
+                    }
+                    else
+                        break;
+                }
+
                 if(strcmp(name, "show_hidden") == 0)
                     priv->show_hidden = (value[0] == '1') ? TRUE : FALSE;
                 else if(strcmp(name, "recursive") == 0)


### PR DESCRIPTION
A search URI whose parameter has no value, such as `search:///home?show_hidden`, makes `parse_search_uri()` set `value` to NULL and then dereference it in the handler (`value[0]`), crashing pcmanfm. `gcc -fanalyzer` also flags the NULL dereference at vfs-search.c:490.

Skip a parameter that has no value instead of dereferencing NULL, freeing the parsed name and continuing with the next pair. A value-less parameter carries no information, so ignoring it matches the intended behavior.

Closes #125